### PR TITLE
[1.12] Fix overriding dig speed

### DIFF
--- a/src/main/java/wards/function/WardFunctionEvent.java
+++ b/src/main/java/wards/function/WardFunctionEvent.java
@@ -228,7 +228,7 @@ public class WardFunctionEvent
 	@SubscribeEvent
 	public void onBreakingBlock(PlayerEvent.BreakSpeed event)
 	{
-		float speed = event.getOriginalSpeed();
+		float speed = event.getNewSpeed();
 		EntityPlayer player = event.getEntityPlayer();
 		for(PotionEffect effect : player.getActivePotionEffects())
 		{


### PR DESCRIPTION
The original speed is unmodified by other event handlers, so this event basically nullifies any dig speed modifiers that are loaded before this mod. This PR aims to fix that by using the modified speed instead.